### PR TITLE
fix: indent codeblocks should work

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,7 +13,7 @@ class Renderer extends marked.Renderer {
     return `<h${level} id="${slug}"><a class="anchor" aria-hidden="true" tabindex="-1" href="#${slug}"><svg class="octicon octicon-link" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>${text}</h${level}>`;
   }
 
-  code(code: string, language: string) {
+  code(code: string, language?: string) {
     // a language of `ts, ignore` should really be `ts`
     language = language?.split(",")?.[0];
     const grammar = Object.hasOwnProperty.call(Prism.languages, language)

--- a/mod.ts
+++ b/mod.ts
@@ -15,7 +15,7 @@ class Renderer extends marked.Renderer {
 
   code(code: string, language: string) {
     // a language of `ts, ignore` should really be `ts`
-    language = language.split(",")[0];
+    language = language?.split(",")?.[0];
     const grammar = Object.hasOwnProperty.call(Prism.languages, language)
       ? Prism.languages[language]
       : undefined;

--- a/mod.ts
+++ b/mod.ts
@@ -16,13 +16,14 @@ class Renderer extends marked.Renderer {
   code(code: string, language?: string) {
     // a language of `ts, ignore` should really be `ts`
     language = language?.split(",")?.[0];
-    const grammar = Object.hasOwnProperty.call(Prism.languages, language)
-      ? Prism.languages[language]
-      : undefined;
+    const grammar =
+      language && Object.hasOwnProperty.call(Prism.languages, language)
+        ? Prism.languages[language]
+        : undefined;
     if (grammar === undefined) {
       return `<pre><code>${htmlEscape(code)}</code></pre>`;
     }
-    const html = Prism.highlight(code, grammar, language);
+    const html = Prism.highlight(code, grammar, language!);
     return `<div class="highlight highlight-source-${language}"><pre>${html}</pre></div>`;
   }
 

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,9 @@
+import {render} from "./mod.ts";
+
+console.log(render(`
+If you are looking for the documentation proper, skip to:
+
+    "printf: prints formatted output"
+
+and
+`));

--- a/test.ts
+++ b/test.ts
@@ -1,9 +1,0 @@
-import {render} from "./mod.ts";
-
-console.log(render(`
-If you are looking for the documentation proper, skip to:
-
-    "printf: prints formatted output"
-
-and
-`));


### PR DESCRIPTION
Currently indent-based codeblocks (https://github.com/denoland/deno_std/blob/main/fmt/README.md?plain=1#L8) do not work as marked passes `language` as `undefined`.
Needed for https://github.com/denoland/dotland/issues/2031