### PR TITLE
Proposal: Use notranslate class to <code> tag

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -21,10 +21,10 @@ class Renderer extends Marked.Renderer {
         ? Prism.languages[language]
         : undefined;
     if (grammar === undefined) {
-      return `<pre><code>${htmlEscape(code)}</code></pre>`;
+      return `<pre><code class="notranslate">${htmlEscape(code)}</code></pre>`;
     }
     const html = Prism.highlight(code, grammar, language!);
-    return `<div class="highlight highlight-source-${language}"><pre>${html}</pre></div>`;
+    return `<div class="highlight highlight-source-${language} notranslate"><pre>${html}</pre></div>`;
   }
 
   link(href: string, title: string, text: string) {
@@ -86,7 +86,7 @@ export function render(markdown: string, opts: RenderOptions = {}): string {
       iframe: ["src", "width", "height"], // Only used when iframe tags are allowed in the first place.
     },
     allowedClasses: {
-      div: ["highlight"],
+      div: ["highlight", "notranslate"],
       span: [
         "token",
         "keyword",


### PR DESCRIPTION
If a viewer uses translation software (such as Google Translate) to view a page, it is inconvenient for the contents of the code block to be translated.
In Github, div tags surrounding code tags have the class notranslate

https://comfortable-toad-66.deno.dev

This is a page where you can see the effect of notranslate.
The upper block does not have a notranslate, the lower block does.

If you use a translation function such as Chrome, you can see that the contents of the code tag in the block below are not translated. This is the same behavior as Github

<img width="545" alt="image" src="https://user-images.githubusercontent.com/45391880/183106370-d6fefff1-0a32-4fe2-8436-eee0a3b831d0.png">

Sorry my poor English
https://dash.deno.com/playground/comfortable-toad-66