### PR TITLE
Case-insensitive language support

### DIFF
--- a/example/content.md
+++ b/example/content.md
@@ -1,4 +1,4 @@
-```json
+```JSON
 {
   "json": {
     "name": "Deno"

--- a/mod.ts
+++ b/mod.ts
@@ -15,7 +15,8 @@ class Renderer extends Marked.Renderer {
 
   code(code: string, language?: string) {
     // a language of `ts, ignore` should really be `ts`
-    language = language?.split(",")?.[0];
+    // and it should be lowercase to ensure it has parity with regular github markdown
+    language = language?.split(",")?.[0].toLocaleLowerCase();
     const grammar =
       language && Object.hasOwnProperty.call(Prism.languages, language)
         ? Prism.languages[language]


### PR DESCRIPTION
Upstream from this [dotland issue](https://github.com/denoland/dotland/issues/2529).

Adds support for non-lowercase languages for code blocks.